### PR TITLE
Replace `Object.keys` with standard `for in` for wider support

### DIFF
--- a/packages/jsmapper/mapper/default.js
+++ b/packages/jsmapper/mapper/default.js
@@ -32,12 +32,12 @@ JsMapper.Mapper.Default = (function() {
      * @returns Object
      */
 	Mapper.prototype.mapProperties = function(object, model) {
-		Object.keys(object).forEach(function(key) {
-			if (!object.hasOwnProperty(key)) {
-				return;
-			}
-			model[key] = object[key];
-		});
+        for (var key in object) {
+            if (!object.hasOwnProperty(key)) {
+                continue;
+            }
+            model[key] = object[key];
+        }
 		return model;
 	};
 

--- a/packages/jsmapper/transport/xml-http-request.js
+++ b/packages/jsmapper/transport/xml-http-request.js
@@ -66,16 +66,18 @@ JsMapper.Transport.XmlHttpRequest = (function() {
 
         // Set request headers
         if (options.headers) {
-            Object.keys(options.headers).forEach(function(key) {
+
+            for (var key in options.headers) {
 
                 // Don't attempt to utilise any properties from the prototype chain
                 if (!options.headers.hasOwnProperty(key)) {
-                    return;
+                    continue;
                 }
 
                 // Set the header for this request
                 client.setRequestHeader(key, options.headers[key]);
-            });
+
+            }
         }
 
         // Send the request


### PR DESCRIPTION
Replaced the fairly recent addition of `Object.keys` with the good old fashioned `for in` loop. The advantage being that `jsmapper` will be supported in more browsers, yet maintains exactly the same functionality.
