### PR TITLE
Replace `create` instantiation method with `new` for wider support

### DIFF
--- a/packages/jsmapper/mapper/promise.js
+++ b/packages/jsmapper/mapper/promise.js
@@ -19,7 +19,7 @@ JsMapper.Mapper.Promise = (function() {
     /**
      * Extend the default Mapper
      */
-    PromiseMapper.prototype = Object.create(Mapper.prototype);
+    PromiseMapper.prototype = new Mapper();
 
     /**
      * This method ensures that we always use the correct


### PR DESCRIPTION
It's unnecessary to use the `create` method, when the `new` construct is much wider supported.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create
